### PR TITLE
manifest(smee): add node affinity for amd64 architecture

### DIFF
--- a/smee/smee-deployment.yaml
+++ b/smee/smee-deployment.yaml
@@ -30,6 +30,15 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
       tolerations:
         - key: "low-spec"
           operator: "Exists"


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity